### PR TITLE
Bump graphviz-java to 0.16.2

### DIFF
--- a/dbml2viz/build.gradle
+++ b/dbml2viz/build.gradle
@@ -14,8 +14,8 @@ dependencies {
     implementation project(":dbml")
     implementation project(":dbml-render")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation 'guru.nidi:graphviz-java:0.16.0'
-    implementation 'guru.nidi:graphviz-java-all-j2v8:0.16.0'
+    implementation 'guru.nidi:graphviz-java:0.16.2'
+    implementation 'guru.nidi:graphviz-java-all-j2v8:0.16.2'
     testImplementation "junit:junit:4.12"
 }
 


### PR DESCRIPTION
On `0.16.0`, the screen flickers on MacOS due to `graphviz-java` using AWT classes without drawing on the screen. Using headless mode fixes it, which the bump to `0.16.2` accounts for.

See https://github.com/nidi3/graphviz-java/issues/165