### PR TITLE
Add publishing tasks for gradle plugin into maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
         if (includeSampleApp) {
-            classpath "com.zynger.floorplan:floorplan-gradle-plugin:0.1-SNAPSHOT"
+            classpath "com.juliozynger.floorplan:floorplan-gradle-plugin:0.1-SNAPSHOT"
         }
     }
 }
@@ -20,7 +20,7 @@ plugins {
 }
 
 subprojects {
-    group 'com.zynger.floorplan'
+    group 'com.juliozynger.floorplan'
     version '0.1-SNAPSHOT'
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1
+
+Work in progress.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -44,3 +44,82 @@ Deploy it locally:
 ```
 mkdocs serve
 ```
+
+## Release
+
+* Create a local release branch from `master`
+```
+git checkout master
+git pull
+git checkout -b release_<next-release-version>
+```
+
+* Update `version` in the [root `build.gradle`](https://github.com/julioz/FloorPlan/blob/master/build.gradle) (remove `-SNAPSHOT`)
+```gradle
+version = "<next-release-version>"
+```
+
+* Update `docs/changelog.md` after checking out all changes:
+  - https://github.com/julioz/FloorPlan/compare/v`<current-release-version>`...master
+
+* Take one last look
+```
+git diff
+```
+
+* Commit all local changes
+```
+git commit -am "Prepare <next-release-version> release."
+```
+
+* Perform a clean build
+```
+./gradlew clean
+./gradlew build
+```
+
+* Create a tag and push it
+```
+git tag v<next-release-version>
+git push origin v<next-release-version>
+```
+
+* Make sure you have valid credentials in `~/.gradle/gradle.properties` to upload the artifacts
+```
+SONATYPE_NEXUS_USERNAME=
+SONATYPE_NEXUS_PASSWORD=
+```
+
+* Upload the artifacts to Sonatype OSS Nexus
+```
+./gradlew publish --no-daemon --no-parallel
+```
+
+* Release to Maven Central
+  - Login to [Sonatype OSS Nexus](https://oss.sonatype.org/)
+  - Click on **Staging Repositories**
+  - Scroll to the bottom, you should see an entry named `comjuliozynger-XXXX`
+  - Check the box next to the `comjuliozynger-XXXX` entry, click **Close** then **Confirm**
+  - Wait a bit, hit **Refresh**, until the *Status* for that column changes to *Closed*.
+  - Check the box next to the `comjuliozynger-XXXX` entry, click **Release** then **Confirm**
+
+* Merge the release branch to master
+```
+git checkout master
+git pull
+git merge --no-ff release_<next-release-version>
+```
+* Update `version` in `build.gradle` (increase version and add `-SNAPSHOT`)
+```gradle
+version = "REPLACE_WITH_NEXT_VERSION_NUMBER-SNAPSHOT"
+```
+
+* Commit your changes
+```
+git commit -am "Prepare for next development iteration."
+```
+
+* Push your changes
+```
+git push
+```

--- a/docs/gradle-plugin.md
+++ b/docs/gradle-plugin.md
@@ -2,7 +2,7 @@
 
 ### Apply the plugin
 
-Apply the gradle plugin in your root `build.gradle` file:
+Apply the [gradle plugin](https://plugins.gradle.org/plugin/com.zynger.floorplan) in your root `build.gradle` file:
 
 ```
 buildscript {

--- a/docs/gradle-plugin.md
+++ b/docs/gradle-plugin.md
@@ -2,12 +2,12 @@
 
 ### Apply the plugin
 
-Apply the [gradle plugin](https://plugins.gradle.org/plugin/com.zynger.floorplan) in your root `build.gradle` file:
+Apply the [gradle plugin](https://plugins.gradle.org/plugin/com.juliozynger.floorplan) in your root `build.gradle` file:
 
 ```
 buildscript {
   dependencies {
-    classpath "com.zynger.floorplan:floorplan-gradle-plugin:<version>"
+    classpath "com.juliozynger.floorplan:floorplan-gradle-plugin:<version>"
   }
 }
 ```
@@ -19,7 +19,7 @@ For example, in an Android application module:
 ```
 plugins {
     id 'com.android.application' // could be library or any other module
-    id 'com.zynger.floorplan'
+    id 'com.juliozynger.floorplan'
 }
 ```
 

--- a/floorplan-gradle-plugin/build.gradle
+++ b/floorplan-gradle-plugin/build.gradle
@@ -32,6 +32,7 @@ publishing {
     }
     publications {
         shadow(MavenPublication) { publication ->
+            customizePom(pom)
             project.shadow.component(publication)
         }
     }
@@ -88,6 +89,47 @@ artifacts {
 
 signing {
     required = isReleaseBuild
+}
+
+def customizePom(pom) {
+    pom.withXml {
+        def root = asNode()
+
+        // eliminate test-scoped dependencies (no need in maven central POMs)
+        root.dependencies.removeAll { dep ->
+            dep.scope == "test"
+        }
+
+        // add all items necessary for maven central publication
+        root.children().last() + {
+            resolveStrategy = Closure.DELEGATE_FIRST
+
+            description project.description
+            name 'FloorPlan'
+            url 'https://github.com/julioz/FloorPlan'
+            issueManagement {
+                system 'GitHub'
+                url 'https://github.com/julioz/FloorPlan/issues'
+            }
+            licenses {
+                license {
+                    name 'The Apache License, Version 2.0'
+                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                }
+            }
+            scm {
+                url 'https://github.com/julioz/FloorPlan'
+                connection 'scm:git:git://github.com/julioz/FloorPlan.git'
+                developerConnection 'scm:git:ssh://github.com/julioz/FloorPlan.git'
+            }
+            developers {
+                developer {
+                    id 'julioz'
+                    name 'Julio Zynger'
+                }
+            }
+        }
+    }
 }
 
 dependencies {

--- a/floorplan-gradle-plugin/build.gradle
+++ b/floorplan-gradle-plugin/build.gradle
@@ -33,7 +33,7 @@ shadowJar {
 gradlePlugin {
     plugins {
         floorplan {
-            id = "com.zynger.floorplan"
+            id = "com.juliozynger.floorplan"
             displayName = "FloorPlan"
             description = "Render database schemas into ER diagrams"
             implementationClass = 'com.zynger.floorplan.FloorPlanPlugin'

--- a/floorplan-gradle-plugin/build.gradle
+++ b/floorplan-gradle-plugin/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'maven-publish'
     id 'org.jetbrains.kotlin.jvm'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id "com.gradle.plugin-publish" version "0.12.0"
 }
 
 repositories {
@@ -31,10 +32,25 @@ shadowJar {
 
 gradlePlugin {
     plugins {
-        simplePlugin {
-            id = 'com.zynger.floorplan'
+        floorplan {
+            id = "com.zynger.floorplan"
+            displayName = "FloorPlan"
+            description = "Render database schemas into ER diagrams"
             implementationClass = 'com.zynger.floorplan.FloorPlanPlugin'
         }
+    }
+}
+
+
+
+pluginBundle {
+    website = "https://github.com/julioz/FloorPlan"
+    vcsUrl = "https://github.com/julioz/FloorPlan"
+    tags = ["room", "diagram", "er", "graphviz", "android", "floorplan"]
+
+    mavenCoordinates {
+        artifactId = "floorplan-gradle-plugin"
+        groupId = project.group.toString()
     }
 }
 

--- a/floorplan-gradle-plugin/build.gradle
+++ b/floorplan-gradle-plugin/build.gradle
@@ -5,13 +5,31 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'com.github.johnrengelman.shadow' version '5.2.0'
     id "com.gradle.plugin-publish" version "0.12.0"
+    id 'signing'
 }
 
 repositories {
     mavenCentral()
 }
 
+def isReleaseBuild = !version.toString().endsWith("SNAPSHOT")
+
 publishing {
+    repositories {
+        maven {
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            if (isReleaseBuild) {
+                url = releasesRepoUrl
+            } else {
+                url = snapshotsRepoUrl
+            }
+            credentials {
+                username sonatypeUsername
+                password sonatypePassword
+            }
+        }
+    }
     publications {
         shadow(MavenPublication) { publication ->
             project.shadow.component(publication)
@@ -41,8 +59,6 @@ gradlePlugin {
     }
 }
 
-
-
 pluginBundle {
     website = "https://github.com/julioz/FloorPlan"
     vcsUrl = "https://github.com/julioz/FloorPlan"
@@ -52,6 +68,26 @@ pluginBundle {
         artifactId = "floorplan-gradle-plugin"
         groupId = project.group.toString()
     }
+}
+
+task sourceJar(type: Jar) {
+    classifier "sources"
+    from sourceSets.main.allJava
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier "javadoc"
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives jar
+    archives sourceJar
+    archives javadocJar
+}
+
+signing {
+    required = isReleaseBuild
 }
 
 dependencies {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,3 +24,4 @@ nav:
       - 'Gradle Plugin': 'gradle-plugin.md'
   - 'Contributing': 'contributing.md'
   - 'Architecture': 'architecture.md'
+  - 'Changelog': 'changelog.md'

--- a/sample-android-project/build.gradle
+++ b/sample-android-project/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application'
-    id 'com.zynger.floorplan'
+    id 'com.juliozynger.floorplan'
 }
 
 repositories {

--- a/sample-android-project/build.gradle
+++ b/sample-android-project/build.gradle
@@ -37,3 +37,12 @@ dependencies {
 
     testImplementation "junit:junit:4.13"
 }
+
+afterEvaluate { project ->
+    project.tasks.lint {
+        onlyIf  {
+            println 'Skipping Lint task for sample-android-project...'
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/julioz/FloorPlan/issues/35
Follow-up to https://github.com/julioz/FloorPlan/pull/31

[Entry in the Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.juliozynger.floorplan)
[Request for access on Sonatype](https://issues.sonatype.org/browse/OSSRH-58225?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)