### PR TITLE
Add index parsing logic to `:dbml-parser`

### DIFF
--- a/dbml-parser/src/main/kotlin/com/zynger/floorplan/lex/IndexParser.kt
+++ b/dbml-parser/src/main/kotlin/com/zynger/floorplan/lex/IndexParser.kt
@@ -12,13 +12,20 @@ object IndexParser {
 
     private val INDEX_REGEX = Regex("""$INDEX_NAME.*$INDEX_PROPERTIES\s*\n""")
     private val INDEX_NAME_REGEX = Regex("""name:\s*['"](\w+)['"]""")
+    private const val UNNAMED_INDEX = "unnamed_index"
 
     fun parseIndexes(indexContent: String): List<Index> {
         return INDEXES_BLOCK_REGEX.find(indexContent)?.let {
             INDEX_REGEX.findAll(it.groups[1]!!.value).toList().map { indexMatch ->
                 val indexColumns = indexMatch.groups[1]!!.value.split(",").map { columnName -> columnName.trim() }
                 val indexProperties = indexMatch.groups[2]!!.value
-                val indexName = INDEX_NAME_REGEX.find(indexProperties)!!.groups[1]!!.value
+
+                val indexNameMatch = INDEX_NAME_REGEX.find(indexProperties)
+                val indexName = if (indexNameMatch != null) {
+                    indexNameMatch.groups[1]!!.value
+                } else {
+                    UNNAMED_INDEX
+                }
                 Index(
                     name = indexName,
                     columnNames = indexColumns,

--- a/dbml-parser/src/main/kotlin/com/zynger/floorplan/lex/IndexParser.kt
+++ b/dbml-parser/src/main/kotlin/com/zynger/floorplan/lex/IndexParser.kt
@@ -1,0 +1,30 @@
+package com.zynger.floorplan.lex
+
+import com.zynger.floorplan.dbml.Index
+import org.intellij.lang.annotations.Language
+
+object IndexParser {
+
+    val INDEXES_BLOCK_REGEX = Regex("""[Ii]ndexes\s+\{(\s|\n|[^}]+)}""")
+
+    @Language("RegExp") private const val INDEX_NAME = """\((.+)\)"""
+    @Language("RegExp") private const val INDEX_PROPERTIES = """\[([^\]]+)]"""
+
+    private val INDEX_REGEX = Regex("""$INDEX_NAME.*$INDEX_PROPERTIES\s*\n""")
+    private val INDEX_NAME_REGEX = Regex("""name:\s*['"](\w+)['"]""")
+
+    fun parseIndexes(indexContent: String): List<Index> {
+        return INDEXES_BLOCK_REGEX.find(indexContent)?.let {
+            INDEX_REGEX.findAll(it.groups[1]!!.value).toList().map { indexMatch ->
+                val indexColumns = indexMatch.groups[1]!!.value.split(",").map { columnName -> columnName.trim() }
+                val indexProperties = indexMatch.groups[2]!!.value
+                val indexName = INDEX_NAME_REGEX.find(indexProperties)!!.groups[1]!!.value
+                Index(
+                    name = indexName,
+                    columnNames = indexColumns,
+                    unique = indexProperties.contains("unique", ignoreCase = true)
+                )
+            }
+        } ?: emptyList()
+    }
+}

--- a/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/IndexParserTest.kt
+++ b/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/IndexParserTest.kt
@@ -53,6 +53,25 @@ class IndexParserTest {
         assertEquals("post_id", indexes[0].name)
     }
 
+    @Test
+    fun `unique index with no explicit name`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          indexes  {
+            (id, post_id) [unique]
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(1, indexes.size)
+        assertEquals("unnamed_index", indexes[0].name)
+        assertEquals(true, indexes[0].unique)
+    }
+
     @Ignore(value = "Unsupported: advanced usage of index.")
     @Test
     fun `index as expression`() {

--- a/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/IndexParserTest.kt
+++ b/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/IndexParserTest.kt
@@ -1,6 +1,7 @@
 package com.zynger.floorplan.lex
 
 import org.junit.Assert.*
+import org.junit.Ignore
 import org.junit.Test
 
 class IndexParserTest {
@@ -33,6 +34,7 @@ class IndexParserTest {
         assertEquals(0, indexes.size)
     }
 
+    @Ignore(value = "Unsupported: advanced usage of index.")
     @Test
     fun `index with no explicit name`() {
         val input = """
@@ -51,8 +53,9 @@ class IndexParserTest {
         assertEquals("post_id", indexes[0].name)
     }
 
+    @Ignore(value = "Unsupported: advanced usage of index.")
     @Test
-    fun `index with no expression`() {
+    fun `index as expression`() {
         val input = """
           id int [pk]
           post_id int
@@ -86,6 +89,26 @@ class IndexParserTest {
 
         assertEquals("index_post_tags_post_id", indexes[0].name)
         assertEquals("index_post_tags_tag_id", indexes[1].name)
+    }
+
+    @Ignore(value = "Unsupported: advanced usage of index.")
+    @Test
+    fun `generates name of index when not explicitly specified`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          Indexes  {
+            (post_id)
+            (tag_id, post_id)
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals("unnamed_index", indexes[0].name)
+        assertEquals("unnamed_index", indexes[1].name)
     }
 
     @Test

--- a/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/IndexParserTest.kt
+++ b/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/IndexParserTest.kt
@@ -1,0 +1,146 @@
+package com.zynger.floorplan.lex
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class IndexParserTest {
+    @Test
+    fun `no indexes`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(0, indexes.size)
+    }
+
+    @Test
+    fun `no indexes in block`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          Indexes  {
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(0, indexes.size)
+    }
+
+    @Test
+    fun `index with no explicit name`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          indexes  {
+            post_id
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(1, indexes.size)
+        assertEquals("post_id", indexes[0].name)
+    }
+
+    @Test
+    fun `index with no expression`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          indexes  {
+            (`id*3`,`getdate()`)
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(1, indexes.size)
+        assertEquals(listOf("`id*3`", "`getdate()`"), indexes[0].columnNames)
+    }
+
+    @Test
+    fun `parses name of index`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          Indexes  {
+            (post_id) [name:'index_post_tags_post_id', unique]
+            (tag_id) [name:'index_post_tags_tag_id']
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals("index_post_tags_post_id", indexes[0].name)
+        assertEquals("index_post_tags_tag_id", indexes[1].name)
+    }
+
+    @Test
+    fun `parses uniqueness of index`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          Indexes  {
+            (post_id) [name:'index_post_tags_post_id', unique]
+            (tag_id) [name:'index_post_tags_tag_id']
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(true, indexes[0].unique)
+        assertEquals(false, indexes[1].unique)
+    }
+
+    @Test
+    fun `parses multiple of indexes`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          Indexes  {
+            (post_id) [name:'index_post_tags_post_id', unique]
+            (tag_id) [name:'index_post_tags_tag_id']
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(2, indexes.size)
+    }
+
+    @Test
+    fun `parses column names of indexes`() {
+        val input = """
+          id int [pk]
+          post_id int
+          tag_id int
+        
+          Indexes  {
+            (post_id) [name:'index_post_tags_post_id', unique]
+            (tag_id, post_id) [name:'index_post_tags_tag_id']
+          }
+        """.trimIndent()
+
+        val indexes = IndexParser.parseIndexes(input)
+
+        assertEquals(listOf("post_id"), indexes[0].columnNames)
+        assertEquals(listOf("tag_id", "post_id"), indexes[1].columnNames)
+    }
+}

--- a/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/TableParserTest.kt
+++ b/dbml-parser/src/test/kotlin/com/zynger/floorplan/lex/TableParserTest.kt
@@ -1,6 +1,5 @@
 package com.zynger.floorplan.lex
 
-import com.zynger.floorplan.dbml.Index
 import com.zynger.floorplan.dbml.Table
 import org.junit.Assert.*
 import org.junit.Test
@@ -77,7 +76,7 @@ class TableParserTest {
     }
 
     @Test
-    fun `ignores indexes`() {
+    fun `passes index content to be parsed by delegation`() {
         val input = """
             table post_tags [note: 'hey table note']{
               id int [pk]
@@ -86,12 +85,13 @@ class TableParserTest {
 
               Indexes  {
                 (post_id) [name:'index_post_tags_post_id', unique]
+                (tag_id) [name:'index_post_tags_tag_id']
               }
             }
         """.trimIndent()
 
         val tables = TableParser.parseTables(input)
 
-        assertEquals(emptyList<Index>(), tables[0].indexes)
+        assertEquals(2, tables.first().indexes.size)
     }
 }


### PR DESCRIPTION
Fixes #22 

This adds support for basic definition of indexes in DBML `Table` constructs:
```
Indexes {
  (<column names>) [name: '<index name>', <uniqueness>]
}
```

More advanced use-cases (i.e: no name indexes, expression-based indexes) are unsupported.