### PR TITLE
Add DBML consumer using Kotlin Parser module

### DIFF
--- a/consumer-sniffer/src/main/kotlin/com/zynger/floorplan/FloorPlanConsumerSniffer.kt
+++ b/consumer-sniffer/src/main/kotlin/com/zynger/floorplan/FloorPlanConsumerSniffer.kt
@@ -1,5 +1,6 @@
 package com.zynger.floorplan
 
+import com.zynger.floorplan.dbml.DbmlConsumer
 import com.zynger.floorplan.room.RoomConsumer
 import com.zynger.floorplan.sqlite.SqliteConsumer
 import java.io.File
@@ -10,6 +11,7 @@ object FloorPlanConsumerSniffer {
         return when (inputSourceFile.extension) {
             "json" -> RoomConsumer
             "db" -> SqliteConsumer
+            "dbml" -> DbmlConsumer
             else -> throw IllegalArgumentException("Unknown file extension: ${inputSourceFile.extension}")
         }
     }

--- a/dbml-consumer/build.gradle
+++ b/dbml-consumer/build.gradle
@@ -11,11 +11,12 @@ repositories {
 }
 
 dependencies {
-    api project(":consumer")
-    api project(":room-consumer")
-    api project(":sqlite-consumer")
-    api project(":dbml-consumer")
+    implementation project(":consumer")
+    implementation project(":dbml")
+    implementation project(":dbml-parser")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    testImplementation "junit:junit:4.12"
 }
 
 compileKotlin {

--- a/dbml-consumer/src/main/kotlin/com/zynger/floorplan/dbml/DbmlConsumer.kt
+++ b/dbml-consumer/src/main/kotlin/com/zynger/floorplan/dbml/DbmlConsumer.kt
@@ -1,0 +1,11 @@
+package com.zynger.floorplan.dbml
+
+import com.zynger.floorplan.Consumer
+import com.zynger.floorplan.Parser
+import java.io.File
+
+object DbmlConsumer: Consumer {
+    override fun read(src: File): Project {
+        return Parser.parse(src.readText())
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,10 @@ This module has no logic in it other than housing the domain representations of 
 
 This stage of the processing pipeline is responsible for translating the user input files into DBML models, representing each of the entities and relationships.
 
-So far, FloorPlan processes [Room](https://developer.android.com/topic/libraries/architecture/room) schemas by deserializing their JSON representations (see [sample](https://github.com/julioz/FloorPlan/blob/master/samples/tivi-26.json)) on the [`:room-consumer`](https://github.com/julioz/FloorPlan/tree/master/room-consumer) module.
+So far, FloorPlan processes:
+ - [Room](https://developer.android.com/topic/libraries/architecture/room) schemas, by deserializing their JSON representations (see [sample](https://github.com/julioz/FloorPlan/blob/master/samples/tivi-26.json)) on the [`:room-consumer`](https://github.com/julioz/FloorPlan/tree/master/room-consumer) module.
+ - [SQLite](https://www.sqlite.org/) `db` files, by connecting to them via a JDBC driver and query metadata of entities and relationships.
+ - [DBML](https://dbml.org/) schema files.
 
 ### Visualization
 

--- a/samples/dbmlorg-sample.dbml
+++ b/samples/dbmlorg-sample.dbml
@@ -1,0 +1,23 @@
+Table users {
+  id integer
+  username varchar
+  role varchar
+  created_at timestamp
+}
+
+Table posts {
+  id integer [primary key]
+  title varchar
+  body text [note: 'Content of the post']
+  user_id integer
+  status post_status
+  created_at timestamp
+}
+
+Enum post_status {
+  draft
+  published
+  private [note: 'visible via URL only']
+}
+
+Ref: posts.user_id > users.id // many-to-one

--- a/samples/trackuser.dbml
+++ b/samples/trackuser.dbml
@@ -1,0 +1,17 @@
+Table Track {
+  id int [pk, increment, not null]
+  title varchar [note: 'not null']
+}
+
+Table User {
+  id int [pk, increment, not null]
+  name varchar [note: 'not null']
+}
+
+Table TrackCreator {
+  track_id int [pk, not null]
+  user_id int [pk, not null]
+}
+
+Ref: TrackCreator.track_id - Track.id
+Ref: TrackCreator.user_id - User.id

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ include 'consumer'
 include 'consumer-sniffer'
 include 'room-consumer'
 include 'sqlite-consumer'
+include 'dbml-consumer'
 include 'floorplan-gradle-plugin'
 
 if (includeSampleApp) {


### PR DESCRIPTION
In a similar way to https://github.com/julioz/FloorPlan/pull/40, here we introduce a DBML consumer module, that will leverage the already existing `:dbml-parser` to translate text into `Project` object models.

This will allow for the CLI and Gradle Plugins to receive `.dbml` files as input, and generate DBML or ER diagrams as output.