### PR TITLE
Allow for multi format output

### DIFF
--- a/dbml2viz/src/main/kotlin/com/zynger/floorplan/FloorPlan.kt
+++ b/dbml2viz/src/main/kotlin/com/zynger/floorplan/FloorPlan.kt
@@ -19,32 +19,30 @@ object FloorPlan {
         project: Project,
         output: Output
     ) {
-        output.formats.forEach { outputFormat ->
-            if (outputFormat is DBML) {
-                val config = outputFormat.config
-                val settings = Settings(config.creationSqlAsTableNote, config.renderNullableFields)
-                val dbml = ProjectRenderer.render(project, settings)
+        if (output.format is DBML) {
+            val config = output.format.config
+            val settings = Settings(config.creationSqlAsTableNote, config.renderNullableFields)
+            val dbml = ProjectRenderer.render(project, settings)
 
-                when (output.destination) {
-                    Destination.StandardOut -> println(dbml)
-                    is Destination.Disk -> {
-                        output.destination.file.parentFile.mkdirs()
-                        output.destination.file.writeText(dbml)
-                    }
+            when (output.destination) {
+                Destination.StandardOut -> println(dbml)
+                is Destination.Disk -> {
+                    output.destination.file.parentFile.mkdirs()
+                    output.destination.file.writeText(dbml)
                 }
-            } else {
-                val graphviz = graph(project)
-                val renderer = when (outputFormat) {
-                    is DBML -> throw IllegalStateException()
-                    DOT -> graphviz.render(Format.DOT)
-                    SVG -> graphviz.render(Format.SVG)
-                    PNG -> graphviz.render(Format.PNG)
-                }
+            }
+        } else {
+            val graphviz = graph(project)
+            val renderer = when (output.format) {
+                is DBML -> throw IllegalStateException()
+                DOT -> graphviz.render(Format.DOT)
+                SVG -> graphviz.render(Format.SVG)
+                PNG -> graphviz.render(Format.PNG)
+            }
 
-                when (output.destination) {
-                    Destination.StandardOut -> println(renderer.toString())
-                    is Destination.Disk -> renderer.toFile(output.destination.file)
-                }
+            when (output.destination) {
+                Destination.StandardOut -> println(renderer.toString())
+                is Destination.Disk -> renderer.toFile(output.destination.file)
             }
         }
     }

--- a/dbml2viz/src/main/kotlin/com/zynger/floorplan/FloorPlan.kt
+++ b/dbml2viz/src/main/kotlin/com/zynger/floorplan/FloorPlan.kt
@@ -19,31 +19,32 @@ object FloorPlan {
         project: Project,
         output: Output
     ) {
+        output.formats.forEach { outputFormat ->
+            if (outputFormat is DBML) {
+                val config = outputFormat.config
+                val settings = Settings(config.creationSqlAsTableNote, config.renderNullableFields)
+                val dbml = ProjectRenderer.render(project, settings)
 
-        if (output.format is DBML) {
-            val config = output.format.config
-            val settings = Settings(config.creationSqlAsTableNote, config.renderNullableFields)
-            val dbml = ProjectRenderer.render(project, settings)
-
-            when (output.destination) {
-                Destination.StandardOut -> println(dbml)
-                is Destination.Disk -> {
-                    output.destination.file.parentFile.mkdirs()
-                    output.destination.file.writeText(dbml)
+                when (output.destination) {
+                    Destination.StandardOut -> println(dbml)
+                    is Destination.Disk -> {
+                        output.destination.file.parentFile.mkdirs()
+                        output.destination.file.writeText(dbml)
+                    }
                 }
-            }
-        } else {
-            val graphviz = graph(project)
-            val renderer = when (output.format) {
-                is DBML -> throw IllegalStateException()
-                DOT -> graphviz.render(Format.DOT)
-                SVG -> graphviz.render(Format.SVG)
-                PNG -> graphviz.render(Format.PNG)
-            }
+            } else {
+                val graphviz = graph(project)
+                val renderer = when (outputFormat) {
+                    is DBML -> throw IllegalStateException()
+                    DOT -> graphviz.render(Format.DOT)
+                    SVG -> graphviz.render(Format.SVG)
+                    PNG -> graphviz.render(Format.PNG)
+                }
 
-            when (output.destination) {
-                Destination.StandardOut -> println(renderer.toString())
-                is Destination.Disk -> renderer.toFile(output.destination.file)
+                when (output.destination) {
+                    Destination.StandardOut -> println(renderer.toString())
+                    is Destination.Disk -> renderer.toFile(output.destination.file)
+                }
             }
         }
     }

--- a/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
+++ b/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
@@ -32,6 +32,6 @@ sealed class Destination {
 }
 
 data class Output(
-    val formats: List<Format>,
+    val format: Format,
     val destination: Destination
 )

--- a/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
+++ b/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
@@ -32,6 +32,6 @@ sealed class Destination {
 }
 
 data class Output(
-    val format: Format,
+    val formats: List<Format>,
     val destination: Destination
 )

--- a/docs/gradle-plugin.md
+++ b/docs/gradle-plugin.md
@@ -43,7 +43,7 @@ floorPlan {
 
 FloorPlan is able to output different file formats.
 
-Take a look at what a full configuration would look like, defining `DBML` as an output format (and providing [extra configurations for `DBML`](../run/#output-format)):
+Take a look at what a full configuration would look like, defining `DBML` and `SVG` as output formats (and providing [extra configurations for `DBML`](../run/#output-format)):
 
 ```
 floorPlan {
@@ -56,7 +56,7 @@ floorPlan {
             renderNullableFields = false
         }
         svg {
-            enabled = false
+            enabled = true
         }
         png {
             enabled = false
@@ -67,9 +67,6 @@ floorPlan {
     }
 }
 ```
-
-!!! warning
-    So far, you can only specify one output format per run, by defining which one is `enabled`.
 
 ### Generate Floor Plan
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -22,6 +22,13 @@ Currently, the supported formats are:
 - PNG
 - DOT
 
+
+!!! info
+    Multiple output formats can be specified through a comma-separated list:
+    ```
+    gradlew run --args="<path-to-schema-file> --format=<format1>,<format2>,<format3>"
+    ```
+
 !!! info
     When not present, DBML is picked as default value as output format.
 

--- a/floorplan-cli/src/main/kotlin/com/zynger/floorplan/App.kt
+++ b/floorplan-cli/src/main/kotlin/com/zynger/floorplan/App.kt
@@ -13,13 +13,17 @@ fun main(args: Array<String>) {
         .sniff(src)
         .read(src)
 
-    FloorPlan.render(
-        project = project,
-        output = Output(
-            input.mapOutputFormats(),
-            if (input.outputPath == null) Destination.StandardOut else Destination.Disk(File(input.outputPath))
+    val outputFormats = input.mapOutputFormats()
+
+    outputFormats.forEach { outputFormat ->
+        FloorPlan.render(
+            project = project,
+            output = Output(
+                outputFormat,
+                if (input.outputPath == null) Destination.StandardOut else Destination.Disk(File(input.outputPath))
+            )
         )
-    )
+    }
 }
 
 private fun InputParser.Input.mapOutputFormats(): List<Format> {

--- a/floorplan-cli/src/main/kotlin/com/zynger/floorplan/App.kt
+++ b/floorplan-cli/src/main/kotlin/com/zynger/floorplan/App.kt
@@ -16,14 +16,14 @@ fun main(args: Array<String>) {
     FloorPlan.render(
         project = project,
         output = Output(
-            input.mapOutputFormat(),
+            input.mapOutputFormats(),
             if (input.outputPath == null) Destination.StandardOut else Destination.Disk(File(input.outputPath))
         )
     )
 }
 
-private fun InputParser.Input.mapOutputFormat(): Format {
-    return format?.let {
+private fun InputParser.Input.mapOutputFormats(): List<Format> {
+    return formats?.map {
         when (it.trim().toLowerCase()) {
             "dbml" -> Format.DBML(
                 DbmlConfiguration(
@@ -36,10 +36,12 @@ private fun InputParser.Input.mapOutputFormat(): Format {
             "dot" -> Format.DOT
             else -> throw IllegalArgumentException("Unrecognized rendering format: $it. Must be one of dbml, svg, png, dot.")
         }
-    } ?: Format.DBML(
-        DbmlConfiguration(
-            creationSqlAsTableNote,
-            renderNullableFields
+    } ?: listOf(
+        Format.DBML(
+            DbmlConfiguration(
+                creationSqlAsTableNote,
+                renderNullableFields
+            )
         )
     )
 }

--- a/floorplan-cli/src/main/kotlin/com/zynger/floorplan/InputParser.kt
+++ b/floorplan-cli/src/main/kotlin/com/zynger/floorplan/InputParser.kt
@@ -25,7 +25,7 @@ object InputParser {
             Optionally, use:
             
             * $OUTPUT_ARG_KEY: specify an output file for the rendering content.
-            * $FORMAT_ARG_KEY: specify an output format for the rendering content [one of DBML, SVG, PNG, DOT].
+            * $FORMAT_ARG_KEY: specify an output format for the rendering content [one or more of DBML, SVG, PNG, DOT].
             * $CREATION_SQL_AS_TABLE_NOTES_ARG_KEY: adds the SQL used to create tables as notes $onlyDbmlNote.
             * $RENDER_NULLABLE_FIELDS_ARG_KEY: changes the rendering of the data type of nullable fields $onlyDbmlNote.
             

--- a/floorplan-cli/src/main/kotlin/com/zynger/floorplan/InputParser.kt
+++ b/floorplan-cli/src/main/kotlin/com/zynger/floorplan/InputParser.kt
@@ -7,7 +7,7 @@ object InputParser {
     data class Input(
         val schemaPath: String,
         val outputPath: String?,
-        val format: String?,
+        val formats: List<String>?,
         val creationSqlAsTableNote: Boolean,
         val renderNullableFields: Boolean
     )
@@ -35,11 +35,11 @@ object InputParser {
 
         val inputFilePath: String = sanitizeFilePath(args.first())
         val outputFilePath: String? = args.getArgumentValue(OUTPUT_ARG_KEY)?.let { sanitizeFilePath(it) }
-        val format: String? = args.getArgumentValue(FORMAT_ARG_KEY)
+        val formats: List<String>? = args.getArgumentList(FORMAT_ARG_KEY)
         val noteCreationSql = args.argumentExists(CREATION_SQL_AS_TABLE_NOTES_ARG_KEY)
         val renderNullableFields = args.argumentExists(RENDER_NULLABLE_FIELDS_ARG_KEY)
 
-        return Input(inputFilePath, outputFilePath, format, noteCreationSql, renderNullableFields)
+        return Input(inputFilePath, outputFilePath, formats, noteCreationSql, renderNullableFields)
     }
 
     private fun Array<String>.getArgumentValue(argKey: String): String? {
@@ -52,6 +52,19 @@ object InputParser {
             }
 
             argumentPair.substringAfter("=").substringBefore(" ")
+        }
+    }
+
+    private fun Array<String>.getArgumentList(argKey: String, delimiter: String = ","): List<String>? {
+        return if (none { it.contains("--$argKey=") }) {
+            null
+        } else {
+            val argumentPair = find { it.contains("--$argKey=") }!!
+            require(argumentPair.substringAfter("=").trim().isNotEmpty()) {
+                "Please inform a value for the --$argKey argument."
+            }
+
+            argumentPair.substringAfter("=").substringBefore(" ").split(delimiters = *arrayOf(delimiter))
         }
     }
 

--- a/floorplan-cli/src/test/kotlin/com/zynger/floorplan/InputParserTest.kt
+++ b/floorplan-cli/src/test/kotlin/com/zynger/floorplan/InputParserTest.kt
@@ -104,7 +104,7 @@ class InputParserTest {
             )
         )
 
-        assertNull(input.format)
+        assertNull(input.formats)
     }
 
     @Test
@@ -116,7 +116,19 @@ class InputParserTest {
             )
         )
 
-        assertEquals("svg", input.format)
+        assertEquals(listOf("svg"), input.formats)
+    }
+
+    @Test
+    fun `multi output format is defined when argument is specified`() {
+        val input = InputParser.parse(
+            arrayOf(
+                "samples/db.json",
+                "--format=svg,png,dot"
+            )
+        )
+
+        assertEquals(listOf("svg", "png", "dot"), input.formats)
     }
 
     @Test

--- a/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/FloorPlanPlugin.kt
+++ b/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/FloorPlanPlugin.kt
@@ -28,26 +28,27 @@ class FloorPlanPlugin: Plugin<Project> {
 
                     task.schemaLocation = File(floorPlanExtension.schemaLocation.get())
                     task.outputLocation = File(floorPlanExtension.outputLocation.get())
-                    task.outputFormat = outputFormatExtension.getFormat()
+                    task.outputFormats = outputFormatExtension.getFormats()
                 }
         }
     }
 
-    private fun OutputFormatExtension.getFormat(): OutputFormat {
+    private fun OutputFormatExtension.getFormats(): List<OutputFormat> {
         val outputFormats = getEnabledOutputFormats(this)
         check(outputFormats.isNotEmpty()) { "There are no enabled output formats." }
-        check(outputFormats.size == 1) { "There can only be one enabled output format." }
 
-        return when (val output = outputFormats.first()) {
-            is DbmlConfigurationExtension -> OutputFormat.DBML(
-                DbmlConfiguration(
-                    output.creationSqlAsTableNote.get(),
-                    output.renderNullableFields.get()
+        return outputFormats.map { output ->
+            when (output) {
+                is DbmlConfigurationExtension -> OutputFormat.DBML(
+                    DbmlConfiguration(
+                        output.creationSqlAsTableNote.get(),
+                        output.renderNullableFields.get()
+                    )
                 )
-            )
-            is SvgConfigurationExtension -> OutputFormat.SVG
-            is PngConfigurationExtension -> OutputFormat.PNG
-            is DotConfigurationExtension -> OutputFormat.DOT
+                is SvgConfigurationExtension -> OutputFormat.SVG
+                is PngConfigurationExtension -> OutputFormat.PNG
+                is DotConfigurationExtension -> OutputFormat.DOT
+            }
         }
     }
 

--- a/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/FloorPlanTask.kt
+++ b/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/FloorPlanTask.kt
@@ -14,7 +14,7 @@ open class FloorPlanTask : DefaultTask() {
     lateinit var schemaLocation: File
 
     @get:Nested
-    lateinit var outputFormat: OutputFormat
+    lateinit var outputFormats: List<OutputFormat>
 
     @OutputDirectory
     lateinit var outputLocation: File
@@ -33,17 +33,20 @@ open class FloorPlanTask : DefaultTask() {
 
         schemas.forEach { schema ->
             val outputHandler = OutputParameterHandler(schema, schemaLocation)
-            val outputFormat: Format = outputHandler.format(outputFormat)
-            val outputFile: File = outputHandler.file(outputLocation, outputFormat)
+            val outputFormats: List<Format> = outputHandler.formats(outputFormats)
 
             val project: Project = FloorPlanConsumerSniffer
                 .sniff(schema)
                 .read(schema)
 
-            FloorPlan.render(
-                project = project,
-                output = Output(outputFormat, Destination.Disk(outputFile))
-            )
+            outputFormats.forEach { outputFormat ->
+                val outputFile: File = outputHandler.file(outputLocation, outputFormat)
+
+                FloorPlan.render(
+                    project = project,
+                    output = Output(outputFormat, Destination.Disk(outputFile))
+                )
+            }
         }
     }
 

--- a/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/OutputParameterHandler.kt
+++ b/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/OutputParameterHandler.kt
@@ -10,8 +10,8 @@ class OutputParameterHandler(
     private val schemaLocation: File
 ) {
 
-    fun format(outputFormat: OutputFormat): Format {
-        return outputFormat.mapOutputFormat()
+    fun formats(outputFormats: List<OutputFormat>): List<Format> {
+        return outputFormats.map { it.mapOutputFormat() }
     }
 
     private fun OutputFormat.mapOutputFormat(): Format {

--- a/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/FloorPlanGradlePluginIntegrationTest.kt
+++ b/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/FloorPlanGradlePluginIntegrationTest.kt
@@ -214,7 +214,7 @@ class FloorPlanGradlePluginIntegrationTest {
             .withSuccessfulMessage()
     }
 
-    @Ignore("Unsupported feature. To be worked on.")
+    @Ignore("Unsupported feature. To be worked on. See https://github.com/julioz/FloorPlan/issues/34")
     @Test
     fun testSingleOutputFormatEnabledWithCollapsibleStatement() {
         createSchemasDirectory()

--- a/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/FloorPlanGradlePluginIntegrationTest.kt
+++ b/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/FloorPlanGradlePluginIntegrationTest.kt
@@ -161,8 +161,8 @@ class FloorPlanGradlePluginIntegrationTest {
              |}""".trimMargin()
         )
         floorPlanRunner()
-            .buildAndFail()
-            .withFailureMessage("There can only be one enabled output format.")
+            .build()
+            .withSuccessfulMessage()
     }
 
     @Test

--- a/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/gradle/OutputParameterHandlerTest.kt
+++ b/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/gradle/OutputParameterHandlerTest.kt
@@ -14,36 +14,45 @@ class OutputParameterHandlerTest {
     fun `dbml gets mapped to output format`() {
         val outputParameterHandler = OutputParameterHandler(SCHEMA, SCHEMA_LOCATION)
 
-        val format = outputParameterHandler.format(OutputFormat.DBML(GradlePluginDbmlConfiguration()))
+        val format = outputParameterHandler.formats(listOf(OutputFormat.DBML(GradlePluginDbmlConfiguration())))
 
-        assertThat(format).isEqualTo(Format.DBML(DbmlConfiguration()))
+        assertThat(format).isEqualTo(listOf(Format.DBML(DbmlConfiguration())))
     }
 
     @Test
     fun `svg gets mapped to output format`() {
         val outputParameterHandler = OutputParameterHandler(SCHEMA, SCHEMA_LOCATION)
 
-        val format = outputParameterHandler.format(OutputFormat.SVG)
+        val format = outputParameterHandler.formats(listOf(OutputFormat.SVG))
 
-        assertThat(format).isEqualTo(Format.SVG)
+        assertThat(format).isEqualTo(listOf(Format.SVG))
     }
 
     @Test
     fun `png gets mapped to output format`() {
         val outputParameterHandler = OutputParameterHandler(SCHEMA, SCHEMA_LOCATION)
 
-        val format = outputParameterHandler.format(OutputFormat.PNG)
+        val format = outputParameterHandler.formats(listOf(OutputFormat.PNG))
 
-        assertThat(format).isEqualTo(Format.PNG)
+        assertThat(format).isEqualTo(listOf(Format.PNG))
     }
 
     @Test
     fun `dot gets mapped to output format`() {
         val outputParameterHandler = OutputParameterHandler(SCHEMA, SCHEMA_LOCATION)
 
-        val format = outputParameterHandler.format(OutputFormat.DOT)
+        val format = outputParameterHandler.formats(listOf(OutputFormat.DOT))
 
-        assertThat(format).isEqualTo(Format.DOT)
+        assertThat(format).isEqualTo(listOf(Format.DOT))
+    }
+
+    @Test
+    fun `multiple outputs get mapped to output format`() {
+        val outputParameterHandler = OutputParameterHandler(SCHEMA, SCHEMA_LOCATION)
+
+        val format = outputParameterHandler.formats(listOf(OutputFormat.SVG, OutputFormat.DOT))
+
+        assertThat(format).isEqualTo(listOf(Format.SVG, Format.DOT))
     }
 
     @Test

--- a/sample-android-project/build.gradle
+++ b/sample-android-project/build.gradle
@@ -22,12 +22,15 @@ android {
 
 floorPlan {
     schemaLocation = "$projectDir/schemas".toString()
-    outputLocation = "$projectDir/schemas".toString()
+    outputLocation = "$projectDir/outputs".toString()
     outputFormat {
         dbml {
             enabled = true
             creationSqlAsTableNote = true
             renderNullableFields = true
+        }
+        svg {
+            enabled = true
         }
     }
 }


### PR DESCRIPTION
Fixes #45

Enables multi format output, so that users can mix-and-match renderings as they seem fit.

The interface through the CLI now takes comma-separated `List` of `--format` arguments.
The Gradle Plugin was updated to allow for multiple `enabled` `outputFormat` definitions.