### PR TITLE
Render diagrams with Crow's Foot notation

### DIFF
--- a/dbml2viz/src/main/kotlin/com/zynger/floorplan/FloorPlan.kt
+++ b/dbml2viz/src/main/kotlin/com/zynger/floorplan/FloorPlan.kt
@@ -141,10 +141,10 @@ object FloorPlan {
          */
         val teeTee = Arrow.TEE.and(Arrow.TEE)
         val crow = Arrow.CROW
-        val (arrowhead, arrowtail) = when (reference.referenceOrder) {
+        val (arrowtail, arrowhead) = when (reference.referenceOrder) {
             ReferenceOrder.OneToOne -> teeTee to teeTee
             ReferenceOrder.OneToMany -> teeTee to crow
-            ReferenceOrder.ManyToOne -> crow to crow
+            ReferenceOrder.ManyToOne -> crow to teeTee
         }
 
         val attributes: Attributes<ForLink> = attrs(

--- a/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
+++ b/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
@@ -46,5 +46,6 @@ sealed class Destination {
 
 data class Output(
     val format: Format,
+    val notation: Notation,
     val destination: Destination
 )

--- a/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
+++ b/dbml2viz/src/main/kotlin/com/zynger/floorplan/Output.kt
@@ -21,6 +21,19 @@ sealed class Format {
     }
 }
 
+sealed class Notation {
+    abstract val identifier: String
+    object Chen: Notation() {
+        override val identifier: String = "chen"
+    }
+    object CrowsFoot: Notation() {
+        override val identifier: String = "crowsfoot"
+    }
+    companion object {
+        val all = listOf(Chen, CrowsFoot)
+    }
+}
+
 data class DbmlConfiguration(
     val creationSqlAsTableNote: Boolean = false,
     val renderNullableFields: Boolean = false

--- a/docs/gradle-plugin.md
+++ b/docs/gradle-plugin.md
@@ -68,6 +68,25 @@ floorPlan {
 }
 ```
 
+#### ERD Notation
+
+FloorPlan supports rendering entity-relationship diagrams using different notations.
+
+```
+floorPlan {
+    schemaLocation = "$projectDir/schemas".toString()
+    outputLocation = "$projectDir/floorplan-output".toString()
+    notation = "crowsfoot"
+    outputFormat {
+        svg {
+            enabled = true
+        }
+    }
+}
+```
+
+Check [this page](../run/#supported-notations) for the supported notations list.
+
 ### Generate Floor Plan
 
 Once everything is setup, you can finally run FloorPlan to translate database schemas into ER diagrams.

--- a/docs/images/notation-chen.svg
+++ b/docs/images/notation-chen.svg
@@ -1,0 +1,63 @@
+<svg width="493px" height="248px"
+ viewBox="0.00 0.00 492.66 248.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 212)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-212 456.66,-212 456.66,36 -36,36"/>
+<!-- users -->
+<g id="node1" class="node">
+<title>users</title>
+<g id="a_node1"><a xlink:title="Table users&#10;Note: Stores user data&#10;Alias: U">
+<polygon fill="#caff70" stroke="transparent" points="292.16,-88 292.16,-110 421.16,-110 421.16,-88 292.16,-88"/>
+<polygon fill="none" stroke="black" points="292.16,-88 292.16,-110 421.16,-110 421.16,-88 292.16,-88"/>
+<text text-anchor="start" x="342.28" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="292.16,-66 292.16,-88 421.16,-88 421.16,-66 292.16,-66"/>
+<text text-anchor="start" x="328.08" y="-73.4" font-family="Times,serif" font-size="14.00">id: </text>
+<text text-anchor="start" x="346.37" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">integer</text>
+<polygon fill="none" stroke="black" points="292.16,-44 292.16,-66 421.16,-66 421.16,-44 292.16,-44"/>
+<text text-anchor="start" x="305.16" y="-51.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="366.19" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">varchar</text>
+<polygon fill="none" stroke="black" points="292.16,-22 292.16,-44 421.16,-44 421.16,-22 292.16,-22"/>
+<text text-anchor="start" x="321.1" y="-29.4" font-family="Times,serif" font-size="14.00">role: </text>
+<text text-anchor="start" x="350.26" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">varchar</text>
+<polygon fill="none" stroke="black" points="292.16,0 292.16,-22 421.16,-22 421.16,0 292.16,0"/>
+<text text-anchor="start" x="295.04" y="-7.4" font-family="Times,serif" font-size="14.00">created_at: </text>
+<text text-anchor="start" x="359.95" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">timestamp</text>
+</a>
+</g>
+</g>
+<!-- posts -->
+<g id="node2" class="node">
+<title>posts</title>
+<g id="a_node2"><a xlink:title="Table posts&#10;Note: Stores blog posts">
+<polygon fill="#caff70" stroke="transparent" points="0.5,-154 0.5,-176 129.5,-176 129.5,-154 0.5,-154"/>
+<polygon fill="none" stroke="black" points="0.5,-154 0.5,-176 129.5,-176 129.5,-154 0.5,-154"/>
+<text text-anchor="start" x="50.61" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">posts</text>
+<polygon fill="none" stroke="black" points="0.5,-132 0.5,-154 129.5,-154 129.5,-132 0.5,-132"/>
+<text text-anchor="start" x="36.42" y="-139.4" font-family="Times,serif" font-size="14.00">id: </text>
+<text text-anchor="start" x="54.71" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">integer</text>
+<polygon fill="none" stroke="black" points="0.5,-110 0.5,-132 129.5,-132 129.5,-110 0.5,-110"/>
+<text text-anchor="start" x="29.43" y="-117.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="58.6" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">varchar</text>
+<polygon fill="none" stroke="black" points="0.5,-88 0.5,-110 129.5,-110 129.5,-88 0.5,-88"/>
+<text text-anchor="start" x="36.81" y="-95.4" font-family="Times,serif" font-size="14.00">body: </text>
+<text text-anchor="start" x="72.2" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">text</text>
+<polygon fill="none" stroke="black" points="0.5,-66 0.5,-88 129.5,-88 129.5,-66 0.5,-66"/>
+<text text-anchor="start" x="21.26" y="-73.4" font-family="Times,serif" font-size="14.00">user_id: </text>
+<text text-anchor="start" x="69.86" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">integer</text>
+<polygon fill="none" stroke="black" points="0.5,-44 0.5,-66 129.5,-66 129.5,-44 0.5,-44"/>
+<text text-anchor="start" x="14.25" y="-51.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="53.53" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">post_status</text>
+<polygon fill="none" stroke="black" points="0.5,-22 0.5,-44 129.5,-44 129.5,-22 0.5,-22"/>
+<text text-anchor="start" x="3.38" y="-29.4" font-family="Times,serif" font-size="14.00">created_at: </text>
+<text text-anchor="start" x="68.29" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">timestamp</text>
+</a>
+</g>
+</g>
+<!-- posts&#45;&gt;users -->
+<g id="edge1" class="edge">
+<title>posts:user_id&#45;&gt;users:id</title>
+<path fill="none" stroke="black" stroke-dasharray="5,2" d="M129,-77C197.76,-77 217.47,-77 281.45,-77"/>
+<polygon fill="black" stroke="black" points="281.66,-80.5 291.66,-77 281.66,-73.5 281.66,-80.5"/>
+<text text-anchor="middle" x="210.33" y="-81.2" font-family="Times,serif" font-size="14.00">*&#45;1</text>
+</g>
+</g>
+</svg>

--- a/docs/images/notation-crowsfoot.svg
+++ b/docs/images/notation-crowsfoot.svg
@@ -1,0 +1,66 @@
+<svg width="474px" height="248px"
+ viewBox="0.00 0.00 474.00 248.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph0" class="graph" transform="scale(1.0 1.0) rotate(0) translate(36 212)">
+<polygon fill="white" stroke="transparent" points="-36,36 -36,-212 438,-212 438,36 -36,36"/>
+<!-- users -->
+<g id="node1" class="node">
+<title>users</title>
+<g id="a_node1"><a xlink:title="Table users&#10;Note: Stores user data&#10;Alias: U">
+<polygon fill="#caff70" stroke="transparent" points="273.5,-88 273.5,-110 402.5,-110 402.5,-88 273.5,-88"/>
+<polygon fill="none" stroke="black" points="273.5,-88 273.5,-110 402.5,-110 402.5,-88 273.5,-88"/>
+<text text-anchor="start" x="323.62" y="-95.4" font-family="Times,serif" font-weight="bold" font-size="14.00">users</text>
+<polygon fill="none" stroke="black" points="273.5,-66 273.5,-88 402.5,-88 402.5,-66 273.5,-66"/>
+<text text-anchor="start" x="309.42" y="-73.4" font-family="Times,serif" font-size="14.00">id: </text>
+<text text-anchor="start" x="327.71" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">integer</text>
+<polygon fill="none" stroke="black" points="273.5,-44 273.5,-66 402.5,-66 402.5,-44 273.5,-44"/>
+<text text-anchor="start" x="286.5" y="-51.4" font-family="Times,serif" font-size="14.00">username: </text>
+<text text-anchor="start" x="347.53" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">varchar</text>
+<polygon fill="none" stroke="black" points="273.5,-22 273.5,-44 402.5,-44 402.5,-22 273.5,-22"/>
+<text text-anchor="start" x="302.44" y="-29.4" font-family="Times,serif" font-size="14.00">role: </text>
+<text text-anchor="start" x="331.6" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">varchar</text>
+<polygon fill="none" stroke="black" points="273.5,0 273.5,-22 402.5,-22 402.5,0 273.5,0"/>
+<text text-anchor="start" x="276.38" y="-7.4" font-family="Times,serif" font-size="14.00">created_at: </text>
+<text text-anchor="start" x="341.29" y="-7.4" font-family="Times,serif" font-style="italic" font-size="14.00">timestamp</text>
+</a>
+</g>
+</g>
+<!-- posts -->
+<g id="node2" class="node">
+<title>posts</title>
+<g id="a_node2"><a xlink:title="Table posts&#10;Note: Stores blog posts">
+<polygon fill="#caff70" stroke="transparent" points="0.5,-154 0.5,-176 129.5,-176 129.5,-154 0.5,-154"/>
+<polygon fill="none" stroke="black" points="0.5,-154 0.5,-176 129.5,-176 129.5,-154 0.5,-154"/>
+<text text-anchor="start" x="50.61" y="-161.4" font-family="Times,serif" font-weight="bold" font-size="14.00">posts</text>
+<polygon fill="none" stroke="black" points="0.5,-132 0.5,-154 129.5,-154 129.5,-132 0.5,-132"/>
+<text text-anchor="start" x="36.42" y="-139.4" font-family="Times,serif" font-size="14.00">id: </text>
+<text text-anchor="start" x="54.71" y="-139.4" font-family="Times,serif" font-style="italic" font-size="14.00">integer</text>
+<polygon fill="none" stroke="black" points="0.5,-110 0.5,-132 129.5,-132 129.5,-110 0.5,-110"/>
+<text text-anchor="start" x="29.43" y="-117.4" font-family="Times,serif" font-size="14.00">title: </text>
+<text text-anchor="start" x="58.6" y="-117.4" font-family="Times,serif" font-style="italic" font-size="14.00">varchar</text>
+<polygon fill="none" stroke="black" points="0.5,-88 0.5,-110 129.5,-110 129.5,-88 0.5,-88"/>
+<text text-anchor="start" x="36.81" y="-95.4" font-family="Times,serif" font-size="14.00">body: </text>
+<text text-anchor="start" x="72.2" y="-95.4" font-family="Times,serif" font-style="italic" font-size="14.00">text</text>
+<polygon fill="none" stroke="black" points="0.5,-66 0.5,-88 129.5,-88 129.5,-66 0.5,-66"/>
+<text text-anchor="start" x="21.26" y="-73.4" font-family="Times,serif" font-size="14.00">user_id: </text>
+<text text-anchor="start" x="69.86" y="-73.4" font-family="Times,serif" font-style="italic" font-size="14.00">integer</text>
+<polygon fill="none" stroke="black" points="0.5,-44 0.5,-66 129.5,-66 129.5,-44 0.5,-44"/>
+<text text-anchor="start" x="14.25" y="-51.4" font-family="Times,serif" font-size="14.00">status: </text>
+<text text-anchor="start" x="53.53" y="-51.4" font-family="Times,serif" font-style="italic" font-size="14.00">post_status</text>
+<polygon fill="none" stroke="black" points="0.5,-22 0.5,-44 129.5,-44 129.5,-22 0.5,-22"/>
+<text text-anchor="start" x="3.38" y="-29.4" font-family="Times,serif" font-size="14.00">created_at: </text>
+<text text-anchor="start" x="68.29" y="-29.4" font-family="Times,serif" font-style="italic" font-size="14.00">timestamp</text>
+</a>
+</g>
+</g>
+<!-- posts&#45;&gt;users -->
+<g id="edge1" class="edge">
+<title>posts:user_id&#45;&gt;users:id</title>
+<path fill="none" stroke="black" d="M139.09,-77C191.62,-77 210.31,-77 262.79,-77"/>
+<polygon fill="black" stroke="black" points="139,-77 129,-72.5 134,-77 129,-77 129,-77 129,-77 134,-77 129,-81.5 139,-77 139,-77"/>
+<polygon fill="black" stroke="black" points="272,-72 272,-82 270,-82 270,-72 272,-72"/>
+<polyline fill="none" stroke="black" points="273,-77 268,-77 "/>
+<polygon fill="black" stroke="black" points="267,-72 267,-82 265,-82 265,-72 267,-72"/>
+<polyline fill="none" stroke="black" points="268,-77 263,-77 "/>
+</g>
+</g>
+</svg>

--- a/docs/run.md
+++ b/docs/run.md
@@ -44,6 +44,21 @@ The directory will be created if it doesn't exist and the input filename will be
 gradlew run --args="<path-to-schema-file> --output <path-to-output-directory>"
 ```
 
+### ERD Notation (`--notation`, `-n`)
+
+FloorPlan supports rendering entity-relationship diagrams using different notations.
+
+```
+gradlew run --args="<path-to-schema-file> --notation <notation-identifier>"
+```
+
+#### Supported notations
+
+| Name | Identifier | Screenshot |
+|---|---|---|
+| Simplified Chen (default) | `chen` | ![chen notation](images/notation-chen.svg) |
+| [Crow's Foot](https://www.vertabelo.com/blog/crow-s-foot-notation/) | `crowsfoot` | ![crow's foot notation](images/notation-crowsfoot.svg) |
+
 ### Add `CREATION SQL` as [Table note](https://www.dbml.org/docs/#table-notes) (`--creation-sql-as-table-note`, `-ctn`)
 
 This option is **disabled by default** since it can be quite verbose and would 'duplicate' what a UI rendering tool (better) provides.

--- a/floorplan-cli/src/main/kotlin/com/zynger/floorplan/FloorPlanCli.kt
+++ b/floorplan-cli/src/main/kotlin/com/zynger/floorplan/FloorPlanCli.kt
@@ -108,6 +108,7 @@ class FloorPlanCli: CliktCommand(
                 project = project,
                 output = Output(
                     format = outputFormat,
+                    notation = notation,
                     destination = destination
                 )
             )

--- a/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/FloorPlanPlugin.kt
+++ b/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/FloorPlanPlugin.kt
@@ -28,8 +28,20 @@ class FloorPlanPlugin: Plugin<Project> {
 
                     task.schemaLocation = File(floorPlanExtension.schemaLocation.get())
                     task.outputLocation = File(floorPlanExtension.outputLocation.get())
+                    task.notation = floorPlanExtension.getNotation()
                     task.outputFormats = outputFormatExtension.getFormats()
                 }
+        }
+    }
+
+    private fun FloorPlanExtension.getNotation(): String? {
+        return if (notation.isPresent && notation.get().trim().isNotEmpty()) {
+            val validNotations = Notation.all.map { it.identifier }
+            val notation = notation.get()
+            check(validNotations.contains(notation)) { "The notation $notation is unsupported." }
+            notation
+        } else {
+            null
         }
     }
 

--- a/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/FloorPlanTask.kt
+++ b/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/FloorPlanTask.kt
@@ -19,6 +19,9 @@ open class FloorPlanTask : DefaultTask() {
     @OutputDirectory
     lateinit var outputLocation: File
 
+    @get:Input @Optional
+    var notation: String? = null
+
     @TaskAction
     fun generateFloorPlan() {
         if (!schemaLocation.exists()) {
@@ -34,6 +37,7 @@ open class FloorPlanTask : DefaultTask() {
         schemas.forEach { schema ->
             val outputHandler = OutputParameterHandler(schema, schemaLocation)
             val outputFormats: List<Format> = outputHandler.formats(outputFormats)
+            val notation: Notation = Notation.all.find { it.identifier == notation } ?: Notation.Chen
 
             val project: Project = FloorPlanConsumerSniffer
                 .sniff(schema)
@@ -44,7 +48,11 @@ open class FloorPlanTask : DefaultTask() {
 
                 FloorPlan.render(
                     project = project,
-                    output = Output(outputFormat, Destination.Disk(outputFile))
+                    output = Output(
+                        format = outputFormat,
+                        notation = notation,
+                        destination = Destination.Disk(outputFile)
+                    )
                 )
             }
         }

--- a/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/extension/FloorPlanExtension.kt
+++ b/floorplan-gradle-plugin/src/main/kotlin/com/zynger/floorplan/gradle/extension/FloorPlanExtension.kt
@@ -11,4 +11,5 @@ constructor(
 ) {
     val schemaLocation: Property<String> = objects.property(String::class.java)
     val outputLocation: Property<String> = objects.property(String::class.java)
+    val notation: Property<String> = objects.property(String::class.java).convention("")
 }

--- a/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/FloorPlanGradlePluginIntegrationTest.kt
+++ b/floorplan-gradle-plugin/src/test/kotlin/com/zynger/floorplan/FloorPlanGradlePluginIntegrationTest.kt
@@ -236,6 +236,102 @@ class FloorPlanGradlePluginIntegrationTest {
             .withSuccessfulMessage()
     }
 
+    @Test
+    fun testNoExplicitNotationDoesNotFailBuild() {
+        createSchemasDirectory()
+        writeBuildGradle(
+            """plugins {
+             |  id "com.zynger.floorplan"
+             |}
+             |
+             |floorPlan {
+             |  schemaLocation = "${"\$projectDir"}/schemas"
+             |  outputLocation = "${"\$projectDir"}/schemas"
+             |  outputFormat {
+             |    svg {
+             |      enabled = true
+             |    }
+             |  }
+             |}""".trimMargin()
+        )
+        floorPlanRunner()
+            .build()
+            .withSuccessfulMessage()
+    }
+
+    @Test
+    fun testChenNotationForDiagram() {
+        createSchemasDirectory()
+        writeBuildGradle(
+            """plugins {
+             |  id "com.zynger.floorplan"
+             |}
+             |
+             |floorPlan {
+             |  schemaLocation = "${"\$projectDir"}/schemas"
+             |  outputLocation = "${"\$projectDir"}/schemas"
+             |  notation = "chen"
+             |  outputFormat {
+             |    svg {
+             |      enabled = true
+             |    }
+             |  }
+             |}""".trimMargin()
+        )
+        floorPlanRunner()
+            .build()
+            .withSuccessfulMessage()
+    }
+
+    @Test
+    fun testCrowsFootNotationForDiagram() {
+        createSchemasDirectory()
+        writeBuildGradle(
+            """plugins {
+             |  id "com.zynger.floorplan"
+             |}
+             |
+             |floorPlan {
+             |  schemaLocation = "${"\$projectDir"}/schemas"
+             |  outputLocation = "${"\$projectDir"}/schemas"
+             |  notation = "crowsfoot"
+             |  outputFormat {
+             |    svg {
+             |      enabled = true
+             |    }
+             |  }
+             |}""".trimMargin()
+        )
+        floorPlanRunner()
+            .build()
+            .withSuccessfulMessage()
+    }
+
+    @Test
+    fun testInvalidNotationFailsBuild() {
+        createSchemasDirectory()
+        val notation = "unsupportednotation"
+        writeBuildGradle(
+            """plugins {
+             |  id "com.zynger.floorplan"
+             |}
+             |
+             |floorPlan {
+             |  schemaLocation = "${"\$projectDir"}/schemas"
+             |  outputLocation = "${"\$projectDir"}/schemas"
+             |  notation = "$notation"
+             |  outputFormat {
+             |    svg {
+             |      enabled = true
+             |    }
+             |  }
+             |}""".trimMargin()
+        )
+        floorPlanRunner()
+            .buildAndFail()
+            .withFailureMessage("The notation $notation is unsupported.")
+    }
+
     private fun floorPlanRunner(): GradleRunner {
         return GradleRunner.create()
             .withProjectDir(testProjectRoot.root)


### PR DESCRIPTION
Fixes #54 

Passing in either `chen` or `crowsfoot` as `--notation` / `-n` argument to the CLI or `notation` into the Gradle Plugin extension will define the notation for the rendering of ER diagrams with Graphviz.

| Name | Identifier | Screenshot |
|---|---|---|
| Simplified Chen (default) | `chen` | ![notation-chen](https://user-images.githubusercontent.com/1541701/91645025-e68d1180-ea41-11ea-8e6a-2d1d42debc62.png) |
| [Crow's Foot](https://www.vertabelo.com/blog/crow-s-foot-notation/) | `crowsfoot` | ![notation-crowsfoot](https://user-images.githubusercontent.com/1541701/91645029-edb41f80-ea41-11ea-84df-318e29169e3a.png) |