### PR TITLE
Expose CLI tool version

### DIFF
--- a/floorplan-cli/build.gradle
+++ b/floorplan-cli/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java'
     id 'org.jetbrains.kotlin.jvm'
 }
+apply from: "../versioning.gradle"
 
 sourceCompatibility = 1.8
 
@@ -13,6 +14,19 @@ repositories {
 
 application {
     mainClassName = "com.zynger.floorplan.FloorPlanCliKt"
+}
+
+task embarkVersionFile() {
+    doLast {
+        def resourcesDir = sourceSets.main.output.resourcesDir
+        resourcesDir.mkdirs()
+        new File(resourcesDir, "floorplan-cli-version.properties").text =
+                """floorPlanVersion=$floorPlanVersion
+                """
+    }
+}
+tasks.named("compileKotlin").configure {
+    finalizedBy "embarkVersionFile"
 }
 
 dependencies {

--- a/floorplan-cli/src/main/kotlin/com/zynger/floorplan/FloorPlanCli.kt
+++ b/floorplan-cli/src/main/kotlin/com/zynger/floorplan/FloorPlanCli.kt
@@ -2,19 +2,28 @@ package com.zynger.floorplan
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
-import com.github.ajalt.clikt.parameters.options.flag
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.split
-import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.path
 import com.zynger.floorplan.dbml.Project
 import java.io.File
+import java.util.*
 
 class FloorPlanCli: CliktCommand(
     name = "floorplan",
     help = "Render SCHEMAPATH as DBML or ER diagram."
 ) {
+    init {
+        val properties = Properties().apply {
+            Thread.currentThread().contextClassLoader
+                .getResource("floorplan-cli-version.properties")!!
+                .openStream()
+                .use { load(it) }
+        }
+        val version = properties["floorPlanVersion"].toString()
+        versionOption(version)
+    }
+
     private val onlyDbmlNote = "[note: only for DBML outputs]"
     private val validFormats = listOf("dbml", "svg", "png", "dot")
     private val validNotation = Notation.all.map { it.identifier }


### PR DESCRIPTION
Fixes #59 

Reading version from Gradle properties and writing a resource file as `Properties` to be read on Clikt app startup.

Enables the command
```
./floorplan-cli --version
```